### PR TITLE
Fix & add

### DIFF
--- a/SharpHelpers/SharpHelpers.UnitTest/Boolean/AtomicBooleanTest.cs
+++ b/SharpHelpers/SharpHelpers.UnitTest/Boolean/AtomicBooleanTest.cs
@@ -1,0 +1,75 @@
+﻿// (c) 2023 SharpCoding
+// This code is licensed under MIT license (see LICENSE.txt for details)using System;
+
+using System.Runtime.InteropServices.ComTypes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpCoding.SharpHelpers;
+
+namespace SharpHelpers.UnitTest.Boolean
+{
+    [TestClass]
+    public class AtomicBooleanTest
+    {
+        [TestMethod]
+        public void TestBool()
+        {
+            var ab1 = new AtomicBoolean();
+
+            var result = ab1 == true;
+            Assert.IsFalse(result);
+
+            ab1 = true;
+            result = ab1 == false;
+            Assert.IsFalse(result);
+
+            result = ab1 == true;
+            Assert.IsTrue(result);
+
+            ab1 = false;
+            result = true == ab1;
+            Assert.IsFalse(result);
+
+            var ab2 = new AtomicBoolean();
+
+            result = ab2 == ab1;
+            Assert.IsTrue(result);
+
+        }
+
+        [TestMethod]
+        public void TestAnd()
+        {
+            var t = new AtomicBoolean(true);
+            var f = new AtomicBoolean(false);
+
+            Assert.IsTrue(t.And(t));
+            Assert.IsFalse(f.And(f));
+            Assert.IsFalse(t.And(f));
+            Assert.IsFalse(f.And(t));
+        }
+
+        [TestMethod]
+        public void TestOr()
+        {
+            var t = new AtomicBoolean(true);
+            var f = new AtomicBoolean(false);
+
+            Assert.IsFalse(f.Or(f));
+            Assert.IsTrue(t.Or(t));
+            Assert.IsTrue(t.Or(f));
+            Assert.IsTrue(f.Or(t));
+        }
+
+        [TestMethod]
+        public void TestXor()
+        {
+            var t = new AtomicBoolean(true);
+            var f = new AtomicBoolean(false);
+
+            Assert.IsFalse(t.Xor(t));
+            Assert.IsFalse(f.Xor(f));
+            Assert.IsTrue(t.Xor(f));
+            Assert.IsTrue(f.Xor(t));
+        }
+    }
+}

--- a/SharpHelpers/SharpHelpers.UnitTest/DateAndTime/DateTimeTest.cs
+++ b/SharpHelpers/SharpHelpers.UnitTest/DateAndTime/DateTimeTest.cs
@@ -1,0 +1,41 @@
+﻿// (c) 2023 SharpCoding
+// This code is licensed under MIT license (see LICENSE.txt for details)
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpCoding.SharpHelpers;
+using System.Linq;
+
+
+namespace SharpHelpers.UnitTest.DateAndTime
+{
+
+
+    [TestClass]
+    public class DateTimeTest
+    {
+        [TestMethod]
+        public void TestDateTimeSmart()
+        {
+            var dtDictionary = new System.Collections.Generic.Dictionary<string, string>()
+                    {
+                        {"M/dd/yyyy hh:mm", "10/11/2023 09:00"},
+                        {"MM/dd/yyyy hh:mm:ss tt zzz", "05/01/2009 01:30:42 PM -05:00"},
+                        {"g", "10/11/2023 09:00"}
+                    };
+
+            DateTimeSmart.AddFormats(dtDictionary.Keys.ToArray());
+
+            foreach (var key in dtDictionary.Keys)
+            {
+                DateTime dt = (DateTimeSmart)dtDictionary[key];
+                Assert.IsFalse(dt == DateTime.MinValue);
+            }
+
+            DateTime dt1 = (DateTimeSmart)"01-05-2023 22:30:55";
+            Assert.IsTrue(dt1 == new DateTime( 2023, 5, 1, 22, 30, 55, DateTimeKind.Local));
+
+        }
+
+    }
+}

--- a/SharpHelpers/SharpHelpers/AtomicBoolean.cs
+++ b/SharpHelpers/SharpHelpers/AtomicBoolean.cs
@@ -1,0 +1,94 @@
+﻿// (c) 2023 SharpCoding
+// This code is licensed under MIT license (see LICENSE.txt for details)using System;
+
+using System;
+using System.Data.Common;
+using System.Threading;
+
+namespace SharpCoding.SharpHelpers
+{
+    /// <summary>
+    /// This class represents a boolean value that may be updated atomically.
+    /// It is designed to be thread-safe and can be used in multi-threaded environments
+    /// where atomic operations are required.
+    /// </summary>
+    public class AtomicBoolean : IEquatable<AtomicBoolean>
+    {
+        public static readonly AtomicBoolean False = new AtomicBoolean(false);
+        public static readonly AtomicBoolean True = new AtomicBoolean(true);
+
+        /// <summary>
+        /// A private integer field that holds the atomic boolean value. It uses 0 for false and 1 for true.
+        /// </summary>
+        private int _value;
+        /// <summary>
+        /// FALSE and TRUE: Private constants representing the integer values of false and true respectively.
+        /// </summary>
+        private const int FALSE = 0;
+        private const int TRUE = 1;
+
+        /// <summary>
+        /// The constructor that initializes the atomic boolean with a specified value.
+        /// It uses the Interlocked.Exchange method to safely set the initial value in a thread-safe manner.
+        /// </summary>
+        /// <param name="value">Initial value of the instance. Is false by default.</param>
+        public AtomicBoolean(bool value = false)
+        {
+            Interlocked.Exchange(ref _value, value ? TRUE : FALSE);
+        }
+
+        /// <summary>
+        /// A private property that gets the current boolean value of the atomic boolean.
+        /// It uses the Interlocked.CompareExchange method to safely get the current value in a thread-safe manner.
+        /// </summary>
+        private bool Value => Interlocked.CompareExchange(ref _value, FALSE, FALSE) == TRUE;
+
+        /// <summary>
+        /// An implicit conversion operator that allows an AtomicBoolean to be used where a bool is expected.
+        /// </summary>
+        /// <param name="abool"></param>
+        public static implicit operator bool(AtomicBoolean abool) => abool.Value;
+
+        /// <summary>
+        /// An implicit conversion operator that allows a bool to be used where an AtomicBoolean is expected.
+        /// </summary>
+        /// <param name="v"></param>
+        public static implicit operator AtomicBoolean(bool v) => new AtomicBoolean(v);
+
+        #region Equality members
+
+        /// <inheritdoc />
+        public bool Equals(AtomicBoolean other)
+        {
+            if (other is null)
+                return false;
+
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return _value == other._value;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+                return false;
+
+            if (ReferenceEquals(this, obj))
+                return true;
+
+            return obj.GetType() == GetType() && Equals((AtomicBoolean)obj);
+        }
+
+        /// <inheritdoc />
+        // ReSharper disable once NonReadonlyMemberInGetHashCode
+        public override int GetHashCode() => _value;
+
+        public static bool operator ==(AtomicBoolean left, AtomicBoolean right) => Equals(left, right);
+
+        public static bool operator !=(AtomicBoolean left, AtomicBoolean right) => !Equals(left, right);
+
+        #endregion
+    }
+}

--- a/SharpHelpers/SharpHelpers/AtomicBooleanHelper.cs
+++ b/SharpHelpers/SharpHelpers/AtomicBooleanHelper.cs
@@ -1,0 +1,65 @@
+﻿// (c) 2023 SharpCoding
+// This code is licensed under MIT license (see LICENSE.txt for details)using System;
+
+namespace SharpCoding.SharpHelpers
+{
+    /// <summary>
+    /// The AtomicBooleanHelper class is a static class that provides extension methods for the AtomicBoolean class. 
+    /// </summary>
+    public static class AtomicBooleanHelper
+    {
+        /// <summary>
+        /// This extension method performs a logical XOR operation on the instance and op2.
+        /// It returns true if the instance is different from op2.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="op2"></param>
+        /// <returns></returns>
+        public static bool Xor(this AtomicBoolean instance, AtomicBoolean op2) => ((bool)instance).Xor(op2);
+
+        /// <summary>
+        /// This extension method performs a logical AND operation on the instance and op2.
+        /// It returns true if both the instance and op2 are true.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="op2"></param>
+        /// <returns></returns>
+        public static bool And(this AtomicBoolean instance, AtomicBoolean op2) => ((bool)instance).And(op2);
+
+        /// <summary>
+        /// This extension method performs a logical OR operation on the instance and op2.
+        /// It returns true if either the instance that invokes the method or op2 is true.
+        /// It also returns true when both are true.
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="op2"></param>
+        /// <returns></returns>
+        public static bool Or(this AtomicBoolean instance, AtomicBoolean op2) => ((bool)instance).Or(op2);
+
+        /// <summary>
+        /// This extension method maps the instance value to one of the two parameters.
+        /// If the value is false or null, it returns falseValue; otherwise, it returns trueValue.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="trueValue"></param>
+        /// <param name="falseValue"></param>
+        /// <returns></returns>
+        //public static string ToStringValues(this AtomicBoolean value, string trueValue, string falseValue) => (value == null || value == false) ? falseValue : trueValue;
+        public static string ToStringValues(this AtomicBoolean value, string trueValue, string falseValue) => (value.GetValueOrDefault() == false) ? falseValue : trueValue;
+
+        /// <summary>
+        /// This extension method retrieves the value of the current AtomicBoolean object or the false value if the object is null.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static AtomicBoolean GetValueOrDefault(this AtomicBoolean value) => value.GetValueOrDefault(AtomicBoolean.False);
+
+        /// <summary>
+        /// This extension method retrieves the value of the current AtomicBoolean object or the defaultValue if the object is null.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="defaultValue"></param>
+        /// <returns></returns>
+        public static AtomicBoolean GetValueOrDefault(this AtomicBoolean value, AtomicBoolean defaultValue) => value ?? defaultValue;
+    }
+}

--- a/SharpHelpers/SharpHelpers/DateTimeSmart.cs
+++ b/SharpHelpers/SharpHelpers/DateTimeSmart.cs
@@ -1,0 +1,153 @@
+﻿// (c) 2023 SharpCoding
+// This code is licensed under MIT license (see LICENSE.txt for details)using System;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+
+namespace SharpCoding.SharpHelpers
+{
+    /// <summary>
+    /// The DateTimeSmart class is a wrapper around the DateTime structure,
+    /// providing additional functionality for cast-from-string operations.
+    /// </summary>
+    public class DateTimeSmart
+    {
+        private static string[] _formats = { "dd-MM-yyyy", "yyyy-MM-dd", "dd-MM-yyyy HH:mm:ss" };
+        /// <summary>
+        /// A private constructor that initializes a new instance of the DateTimeSmart class with a specified DateTime value
+        /// </summary>
+        /// <param name="dateTime"></param>
+        private DateTimeSmart(DateTime dateTime)
+        {
+            DateTime = new DateTime(dateTime.Ticks, dateTime.Kind);
+        }
+
+        /// <summary>
+        /// A private static field that serves as a lock to ensure thread safety when modifying the _formats field.
+        /// </summary>
+        private static readonly object _formatsLocker = new object();
+
+        /// <summary>
+        /// A private static method that checks if a string can be a format string for a DateTime object.
+        /// </summary>
+        /// <param name="format"></param>
+        /// <remarks>
+        /// Nice to have: find a way to validate any format strings regardless of localization and without using try parsing.
+        /// </remarks>
+        /// <returns></returns>
+        private static bool IsValidDateTimeFormat(string format)
+        {
+            try
+            {
+                var dtIn = DateTime.Now.ToString(format);
+                //  This is not a foolproof method.
+                return string.Compare(dtIn, format, StringComparison.InvariantCultureIgnoreCase) != 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+
+        /// <summary>
+        /// A public static method that adds new date formats that the class can handle.
+        /// </summary>
+        /// <param name="formats"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        public static bool AddFormats(params string[] formats)
+        {
+            if (formats == null || formats.Length == 0)
+            {
+                throw new ArgumentNullException(nameof(formats));
+            }
+
+            var extras = formats.Except(_formats).ToList();
+            if (extras.TrueForAll(IsValidDateTimeFormat) == false)
+            {
+                throw new ArgumentException("Some string is not in the right format to parse a DateTime.", nameof(formats));
+            }
+
+            if (extras.Any())
+            {
+                lock (_formatsLocker)
+                {
+                    _formats = _formats.Concat(extras).ToArray();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// A public static method that lists the date formats that the class currently can handle.
+        /// </summary>
+        public static IEnumerable<string> GetCurrentFormats() => _formats;
+
+        /// <summary>
+        /// A private property that gets or sets the internal DateTime value.
+        /// </summary>
+        private DateTime DateTime { get; set; }
+
+        /// <summary>
+        /// An explicit conversion operator that converts a string to a DateTimeSmart object.
+        /// </summary>
+        /// <param name="date"></param>
+        public static explicit operator DateTimeSmart(string date)
+        {
+            DateTime.TryParseExact(date, _formats, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var dateTime);
+            return new DateTimeSmart(dateTime);
+        }
+
+        /// <summary>
+        /// An explicit conversion operator that converts a DateTime object to a DateTimeSmart object.
+        /// </summary>
+        /// <param name="dateTime"></param>
+        public static explicit operator DateTimeSmart(DateTime dateTime)
+        {
+            var dt = dateTime.Kind != DateTimeKind.Unspecified ? dateTime : DateTime.SpecifyKind(dateTime, DateTimeKind.Local);
+            return new DateTimeSmart(dt);
+        }
+
+        /// <summary>
+        /// An implicit conversion operator that converts a DateTimeSmart object to a DateTime object.
+        /// </summary>
+        /// <param name="dummy"></param>
+        public static implicit operator DateTime(DateTimeSmart dummy) => dummy.DateTime;
+
+        /// <summary>
+        /// An override of the ToString method that returns the string representation of the DateTime object
+        /// in the "yyyy-MM-dd HH:mm:ss.fff" format.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => this.ToString("yyyy-MM-dd HH:mm:ss.fff");
+
+        /// <summary>
+        /// Overloads of the ToString method that return the string representation of the DateTime object in a specified format
+        /// </summary>
+        /// <param name="format"></param>
+        /// <returns></returns>
+        public string ToString(string format) => DateTime.ToString(format);
+
+        /// <summary>
+        /// Overloads of the ToString method that return the string representation of the DateTime object in a specified format and with a specified format provider.
+        /// </summary>
+        /// <param name="format"></param>
+        /// <param name="provider"></param>
+        /// <returns></returns>
+        public string ToString(string format, IFormatProvider provider) => DateTime.ToString(format, provider);
+
+        /// <summary>
+        /// Overloads of the ToString method that return the string representation of the DateTime object in a specified format provider.
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <returns></returns>
+        public string ToString(IFormatProvider provider) => DateTime.ToString(provider);
+    }
+}

--- a/SharpHelpers/SharpHelpers/EnumHelper.cs
+++ b/SharpHelpers/SharpHelpers/EnumHelper.cs
@@ -15,8 +15,8 @@ namespace SharpCoding.SharpHelpers
         /// <returns></returns>
         public static string GetDescription(this Enum value)
         {
-            var description = GetAttribute<DescriptionAttribute>(value);
-            return description?.Description;
+            var description = GetAttribute<DescriptionAttribute>(value)?.Description;
+            return string.IsNullOrEmpty(description) ? value.ToString() : description;
         }
 
         /// <summary>


### PR DESCRIPTION
- Fix EnumHelper.GetDescription() : if there is no description attribute, the description is the _ToString()_ of the enum value.
- Add AtomicBoolean: thread-safe management of a boolean
- Add DateTimeSmart: makes it easy to convert a string to a datetime