### PR TITLE
Migrate from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/SharpHelpers/SharpHelpers/ObjectExtensions/ObjectSerializationhelper.cs
+++ b/SharpHelpers/SharpHelpers/ObjectExtensions/ObjectSerializationhelper.cs
@@ -3,7 +3,7 @@
 using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace SharpCoding.SharpHelpers.ObjectExtensions
 {
@@ -16,7 +16,7 @@ namespace SharpCoding.SharpHelpers.ObjectExtensions
         /// <returns></returns>
         public static string SerializeToJson(this object istance)
         {
-            return istance == null ? string.Empty : JsonConvert.SerializeObject(istance);
+            return istance == null ? string.Empty : JsonSerializer.Serialize(istance);
         }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace SharpCoding.SharpHelpers.ObjectExtensions
         /// <returns></returns>
         public static T DeserializeFromJson<T>(this string istance) where T : class
         {
-            return string.IsNullOrEmpty(istance) ? default : JsonConvert.DeserializeObject<T>(istance);
+            return string.IsNullOrEmpty(istance) ? default : JsonSerializer.Deserialize<T>(istance);
         }
 
         /// <summary>

--- a/SharpHelpers/SharpHelpers/SharpHelpers.csproj
+++ b/SharpHelpers/SharpHelpers/SharpHelpers.csproj
@@ -20,9 +20,6 @@
     <PackageIcon>ico.png</PackageIcon>
     <PackageIconUrl />
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\LICENSE">
@@ -37,5 +34,9 @@
 
   <ItemGroup>
     <Compile Remove="RegistryHelpers.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/SharpHelpers/SharpHelpers/StringHelper.cs
+++ b/SharpHelpers/SharpHelpers/StringHelper.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
-using Newtonsoft.Json;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using SharpCoding.SharpHelpers.DomainModel;
 using SharpCoding.SharpHelpers.PrivateMethods;
@@ -223,8 +223,13 @@ namespace SharpCoding.SharpHelpers
         /// <param name="strJson"></param>
         public static T JsonToObject<T>(this string strJson)
         {
-            return JsonConvert.DeserializeObject<T>(strJson,
-                                new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
+            var options = new JsonSerializerOptions
+            {
+                ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles,
+                PropertyNameCaseInsensitive = true
+            };
+
+            return JsonSerializer.Deserialize<T>(strJson, options);
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request removes the dependency on Newtonsoft.Json and replaces it with System.Text.Json.
All serialization and deserialization methods have been updated accordingly.